### PR TITLE
feat: use the --release option when updating helmfile

### DIFF
--- a/pkg/promote/pr.go
+++ b/pkg/promote/pr.go
@@ -78,6 +78,7 @@ func (o *Options) PromoteViaPullRequest(envs []*jxcore.EnvironmentConfig, releas
 					ChartAlias:        o.Alias,
 					Namespace:         o.Namespace,
 					HelmRepositoryURL: o.HelmRepositoryURL,
+					ReleaseName:       o.ReleaseName,
 				},
 				Dir:           dir,
 				Config:        *promoteConfig,

--- a/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml
+++ b/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml
@@ -1,0 +1,8 @@
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+releases:
+- name: dbmigrator
+  labels:
+    job: dbmigrator
+  chart: ./dbmigrator

--- a/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml.1.expected
+++ b/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml.1.expected
@@ -1,0 +1,17 @@
+filepath: ""
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: ./dbmigrator
+  name: dbmigrator
+  labels:
+    job: dbmigrator
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp-foo
+  namespace: jx
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml.2.expected
+++ b/pkg/rules/factory/test_data/helmfile-release-name-option/helmfile.yaml.2.expected
@@ -1,0 +1,17 @@
+filepath: ""
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+- name: dev
+  url: http://chartmuseum-jx.34.78.195.22.nip.io
+releases:
+- chart: ./dbmigrator
+  name: dbmigrator
+  labels:
+    job: dbmigrator
+- chart: dev/myapp
+  version: 1.2.4
+  name: myapp-foo
+  namespace: jx
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/factory/test_data/helmfile-release-name-option/options.yaml
+++ b/pkg/rules/factory/test_data/helmfile-release-name-option/options.yaml
@@ -1,0 +1,2 @@
+# test for when running `jx promote --release myapp-foo`
+release: myapp-foo

--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -139,7 +139,7 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 		if !keepOldReleases {
 			for i := range helmfile.Releases {
 				release := &helmfile.Releases[i]
-				if release.Name == app || release.Name == details.Name {
+				if release.Name == app || release.Name == details.Name || (r.ReleaseName != "" && release.Name == r.ReleaseName) {
 					release.Version = version
 					found = true
 					return nil
@@ -152,8 +152,11 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 				ns = promoteNs
 			}
 			newReleaseName := details.LocalName
+			if r.ReleaseName != "" {
+				newReleaseName = r.ReleaseName
+			}
 			if keepOldReleases {
-				newReleaseName = fmt.Sprintf("%s-%s", details.LocalName, strings.Replace(version, ".", "-", -1))
+				newReleaseName = fmt.Sprintf("%s-%s", newReleaseName, strings.Replace(version, ".", "-", -1))
 			}
 			helmfile.Releases = append(helmfile.Releases, state.ReleaseSpec{
 				Name:      newReleaseName,
@@ -168,7 +171,7 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 	if !keepOldReleases {
 		for i := range helmfile.Releases {
 			release := &helmfile.Releases[i]
-			if (release.Name == app || release.Name == details.Name) && (release.Namespace == promoteNs || isRemoteEnv) {
+			if (release.Name == app || release.Name == details.Name || (r.ReleaseName != "" && release.Name == r.ReleaseName)) && (release.Namespace == promoteNs || isRemoteEnv) {
 				release.Version = version
 				found = true
 				return nil
@@ -178,8 +181,11 @@ func modifyHelmfileApps(r *rules.PromoteRule, helmfile *state.HelmState, promote
 
 	if !found {
 		newReleaseName := details.LocalName
+		if r.ReleaseName != "" {
+			newReleaseName = r.ReleaseName
+		}
 		if keepOldReleases {
-			newReleaseName = fmt.Sprintf("%s-%s", details.LocalName, strings.Replace(version, ".", "-", -1))
+			newReleaseName = fmt.Sprintf("%s-%s", newReleaseName, strings.Replace(version, ".", "-", -1))
 		}
 		helmfile.Releases = append(helmfile.Releases, state.ReleaseSpec{
 			Name:      newReleaseName,

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -23,6 +23,7 @@ type TemplateContext struct {
 	ChartAlias        string
 	Namespace         string
 	HelmRepositoryURL string
+	ReleaseName       string
 }
 
 // RuleFunction a rule function for evaluating the rule


### PR DESCRIPTION
The common use case is to use the `app` name as the `release` name when promoting an app.

This PR addresses the use case of releasing a chart multiple times under different names.

The `jx promote` command supports a `--release` option `The name of the helm release` but it is not used when updating the helmfile.

This PR fixes this, then you can run a command like 

```
jx promote --app foo --release bar --version 1.2.3
```

to generate a helmfile release like

```
releases:
- chart: dev/foo
  version: 1.2.3
  name: bar
```
