### PR TITLE
fix: Improved local check

### DIFF
--- a/pkg/promote/promote_test.go
+++ b/pkg/promote/promote_test.go
@@ -180,13 +180,15 @@ func TestConvertToGitHubPagesURL(t *testing.T) {
 }
 
 func TestIsLocalChartRepository(t *testing.T) {
-	localRepos := []string{"http://jenkins-x-chartmuseum:8080", "http://jenkins-x-chartmuseum", "https://chartmuseum", "http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080", "http://bucketrepo.jx"}
+	localRepos := []string{"http://jenkins-x-chartmuseum:8080", "http://jenkins-x-chartmuseum", "https://chartmuseum",
+		"http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080", "http://bucketrepo.jx", "oci://an-oci-repo/", ""}
 	for _, repo := range localRepos {
 		actual := promote.IsLocalChartRepository(repo)
 		assert.True(t, actual, "should be local repo %s", repo)
 	}
 
-	remoteRepos := []string{"http://foo.bar", "https://chartrepo.mydomain.com"}
+	remoteRepos := []string{"http://foo.bar", "https://chartrepo.mydomain.com", "s3://a.bucket.mydomain.com/jx2",
+		"gcs://another-bucket", "oci://an-oci-repo.mydomain.com/my-repo/"}
 	for _, repo := range remoteRepos {
 		actual := promote.IsLocalChartRepository(repo)
 		assert.False(t, actual, "not local repo %s", repo)


### PR DESCRIPTION
I use an s3 bucket as my chart repository. But `jx promote` doesn't use the configured chart repository, but instead replaces it with a url to bucketrepo or chartmuseum. The cause turned to be errors in IsLocalChartRepository.

So here I have improved the function and also added a comment as to why this check exist. At least I think this is the reason; it's not documented anywhere, including in the PR adding the code.

Also and OCI repo could very well be local to the cluster, so the check ought to be done for such a repo as well.