### PR TITLE
feat: Allow several --env options

### DIFF
--- a/pkg/apis/promote/v1alpha1/types.go
+++ b/pkg/apis/promote/v1alpha1/types.go
@@ -67,10 +67,6 @@ type KptRule struct {
 	// For example if the 'config-root'' directory contains a Config Sync git layout we may want applications to be deployed into the
 	// `config-root/namespaces/myapps` folder. If so set the path to `config-root/namespaces/myapps`
 	Path string `json:"path,omitempty"`
-
-	// Namespace specifies the namespace to deploy applications if using kpt. If specified this value will be used instead
-	// of the Environment.Spec.Namespace in the Environment CRD
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // FileRule specifies how to modify a 'Makefile` or shell script to add a new helm/kpt style command

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -397,14 +397,14 @@ func (o *Options) Run() error {
 			return errors.Wrapf(err, "failed to resolve helm repository URL")
 		}
 	}
-	if len(o.Environments) == 0 && !o.BatchMode {
+	if o.Interactive || !(len(o.Environments) != 0 || o.All || o.AllAutomatic || o.BatchMode) {
 		names := []string{}
 		for _, env := range o.DevEnvContext.Requirements.Environments {
 			if envIsPermanent(&env) {
 				names = append(names, env.Key)
 			}
 		}
-		o.Environments, err = o.Input.SelectNames(names, "Pick environment(s):", false, "please select one or many environments")
+		o.Environments, err = o.Input.SelectNames(names, "Pick environment(s):", o.All, "please select one or many environments")
 		if err != nil {
 			return errors.Wrapf(err, "failed to pick an Environment name")
 		}

--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -398,9 +398,11 @@ func (o *Options) Run() error {
 		}
 	}
 	if o.Interactive || !(len(o.Environments) != 0 || o.All || o.AllAutomatic || o.BatchMode) {
-		names := []string{}
-		for _, env := range o.DevEnvContext.Requirements.Environments {
-			if envIsPermanent(&env) {
+		var names []string
+		envs := o.DevEnvContext.Requirements.Environments
+		for i := range envs {
+			env := &envs[i]
+			if envIsPermanent(env) {
 				names = append(names, env.Key)
 			}
 		}

--- a/pkg/promote/promote_integration_test.go
+++ b/pkg/promote/promote_integration_test.go
@@ -821,7 +821,7 @@ func TestPromoteHelmfileToNamedLocalEnvironment(t *testing.T) {
 	po.DisableGitConfig = true
 	po.Application = appName
 	po.Version = version
-	po.Environment = "staging"
+	po.Environments = []string{"staging"}
 
 	po.NoPoll = true
 	po.BatchMode = true
@@ -933,7 +933,7 @@ func AssertPromoteIntegration(t *testing.T, testCases ...PromoteTestCase) {
 		po.DisableGitConfig = true
 		po.Application = appName
 		po.Version = version
-		po.Environment = envName
+		po.Environments = []string{envName}
 
 		po.NoPoll = true
 		po.BatchMode = true

--- a/pkg/promote/promote_test.go
+++ b/pkg/promote/promote_test.go
@@ -31,7 +31,7 @@ func fakeChooseChart() (string, error) {
 
 func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithArgs(t *testing.T) {
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
+		Environments: []string{"production"}, // --env production
 	}
 
 	promoteOptions.Args = []string{"myArgumentApp"}
@@ -44,8 +44,8 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithArgs(t *testing
 
 func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithFilterFlag(t *testing.T) {
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
-		Filter:      "something",
+		Environments: []string{"production"}, // --env production
+		Filter:       "something",
 	}
 
 	err := promoteOptions.EnsureApplicationNameIsDefined(fakeSearchForChart, fakeDiscoverAppName, fakeChooseChart)
@@ -56,7 +56,7 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithFilterFlag(t *t
 
 func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithBatchFlag(t *testing.T) {
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
+		Environments: []string{"production"}, // --env production
 	}
 
 	promoteOptions.BatchMode = true // --batch-mode
@@ -69,8 +69,8 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithBatchFlag(t *te
 
 func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagWithInteractiveFlag(t *testing.T) {
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
-		Interactive: true,
+		Environments: []string{"production"}, // --env production
+		Interactive:  true,
 	}
 
 	err := promoteOptions.EnsureApplicationNameIsDefined(fakeSearchForChart, fakeDiscoverAppName, fakeChooseChart)
@@ -83,7 +83,7 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlag(t *testing.T) {
 	testhelpers.SkipForWindows(t, "go-expect does not work on windows")
 
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
+		Environments: []string{"production"}, // --env production
 	}
 
 	promoteOptions.Input = &fake.FakeInput{
@@ -100,7 +100,7 @@ func TestEnsureApplicationNameIsDefinedWithoutApplicationFlagUserSaysNo(t *testi
 	testhelpers.SkipForWindows(t, "go-expect does not work on windows")
 
 	promoteOptions := &promote.Options{
-		Environment: "production", // --env production
+		Environments: []string{"production"}, // --env production
 		Input: &fake.FakeInput{
 			Values: map[string]string{"Are you sure you want to promote the application named: myDiscoveredApp?": "N"},
 		},


### PR DESCRIPTION
The option `--promotion-environments` were intended to let you select several environments, but it never worked. (The developer seem to have confused `StringArrayP` with `StringArrayVarP`.) But if it had worked it would have meant the same thing as `--env`, except that it could be given multiple times. So I thought it would be good to get rid of `--promotion-environments`, but make `--env` work as `--promotion-environments` were intended to work.

While at it I did some other clean-up as well:
Removing unused fields and parameters and fixing some warnings.
I removed the need for `--batch-mode` together with `--all` and `--all-auto`

