### PR TITLE
fix: Add msvticket to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,10 @@ approvers:
 - jstrachan
 - rajdavies
 - tomhobson
+- msvticket
 reviewers:
 - rawlingsj
 - jstrachan
 - rajdavies
 - tomhobson
+- msvticket

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,1 @@
-aliases:
-- rawlingsj
-best-approvers:
-- rawlingsj
-best-reviewers:
-- rawlingsj
+aliases: {}


### PR DESCRIPTION
One reason for this PR is to make some change to trigger a build since the last one failed on some seemingly spurious
 error.