### PR TITLE
fix: set GitURL on env to group auto promotions on same repo

### DIFF
--- a/pkg/promote/promote.go
+++ b/pkg/promote/promote.go
@@ -546,6 +546,8 @@ func (o *Options) PromoteAll(pred func(*jxcore.EnvironmentConfig) bool) error {
 			if sourceURL == "" && !env.RemoteCluster && o.DevEnvContext.DevEnv != nil {
 				// let's default to the git repository of the dev environment as we are sharing the git repository across multiple namespaces
 				env.GitURL = o.DevEnvContext.DevEnv.Spec.Source.URL
+			} else {
+				env.GitURL = sourceURL
 			}
 			promoteEnvs = append(promoteEnvs, env)
 		}


### PR DESCRIPTION
The feature to promote multiple auto environments using the same promote PR (original change: #216) may have been broken by #236. Add a line to set the derived `sourceURL` to `env.GitURL` so that it can be matched against when grouping environments.

re #400