### PR TITLE
fix(environments): add support for base branch option for new pull requests

### DIFF
--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -73,7 +73,7 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, pullRequest
 	} else {
 		dir, err = gitclient.CloneToDir(o.Gitter, cloneGitURL, "")
 		if o.BaseBranchName != "" {
-			log.Logger().Infof("checking our remote base branch %s from %s", o.BaseBranchName, gitURL)
+			log.Logger().Infof("checking out remote base branch %s from %s", o.BaseBranchName, gitURL)
 			err = gitclient.CheckoutRemoteBranch(o.Gitter, dir, o.BaseBranchName)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to checkout remote branch %s from %s", o.BaseBranchName, gitURL)

--- a/pkg/environments/gitops.go
+++ b/pkg/environments/gitops.go
@@ -72,6 +72,13 @@ func (o *EnvironmentPullRequestOptions) Create(gitURL, prDir string, pullRequest
 		dir, err = gitclient.SparseCloneToDir(o.Gitter, cloneGitURL, "", true, o.SparseCheckoutPatterns...)
 	} else {
 		dir, err = gitclient.CloneToDir(o.Gitter, cloneGitURL, "")
+		if o.BaseBranchName != "" {
+			log.Logger().Infof("checking our remote base branch %s from %s", o.BaseBranchName, gitURL)
+			err = gitclient.CheckoutRemoteBranch(o.Gitter, dir, o.BaseBranchName)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to checkout remote branch %s from %s", o.BaseBranchName, gitURL)
+			}
+		}
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to clone git URL %s", cloneGitURLSafe)


### PR DESCRIPTION
This PR enables support for using base branch name option in gitops environment module to be able to create pull requests from other remote branches in order to promote versions for different release trains i.e. `1.1.x`, `2.0.x`, etc. 

This is also needed to provide support for `--base-branch-name` option in `jx-updatebot pr` command PR: https://github.com/jenkins-x-plugins/jx-updatebot/pull/52
