### PR TITLE
fix: remove oci prefix from helm url before adding it to helmfile.

### DIFF
--- a/pkg/rules/helmfile/helmfile_rule.go
+++ b/pkg/rules/helmfile/helmfile_rule.go
@@ -239,6 +239,9 @@ func defaultPrefix(appsConfig *state.HelmState, envctx *envctx.EnvironmentContex
 	}
 	found := false
 	oci := false
+	//  we need to remove the oci:// prefix (in case it exists), because helmfile doesn't support the scheme in the repo url for oci based repositories.
+	//  for these repositories, only url without a scheme and the oci: true flag is needed.
+	d.Repository = strings.TrimPrefix(d.Repository, "oci://")
 	if envctx.Requirements != nil {
 		oci = envctx.Requirements.Cluster.ChartKind == jxcore.ChartRepositoryTypeOCI
 	}

--- a/pkg/rules/helmfile/helmfile_rule_test.go
+++ b/pkg/rules/helmfile/helmfile_rule_test.go
@@ -1,0 +1,71 @@
+package helmfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jenkins-x-plugins/jx-promote/pkg/jxtesthelpers"
+	"github.com/jenkins-x-plugins/jx-promote/pkg/promoteconfig"
+	"github.com/jenkins-x-plugins/jx-promote/pkg/rules"
+	"github.com/jenkins-x-plugins/jx-promote/pkg/rules/helmfile"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveOCISchemeFromHelmfileRepositoriesDuringDefaultPrefix(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err, "could not make a temp dir")
+
+	t.Logf("creating tests at %s", tmpDir)
+
+	sourceData := "test_data"
+	fileSlice, err := os.ReadDir(sourceData)
+
+	assert.NoError(t, err)
+
+	ns := "jx"
+	testPromoteNS := "jx"
+	for _, f := range fileSlice {
+		if !f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if name == "jenkins-x-versions" {
+			continue
+		}
+
+		dir := filepath.Join(tmpDir, name)
+
+		src := filepath.Join("test_data", name)
+		err = files.CopyDirOverwrite(src, dir)
+		require.NoError(t, err, "could not copy source data in %s to %s", src, dir)
+
+		cfg, _, err := promoteconfig.Discover(dir, testPromoteNS)
+		require.NoError(t, err, "failed to load cfg dir %s", dir)
+		require.NotNil(t, cfg, "no project cfg found in dir %s", dir)
+
+		envctx := jxtesthelpers.CreateTestDevEnvironmentContext(t, ns)
+		envctx.Requirements.Cluster.ChartKind = "oci"
+
+		r := &rules.PromoteRule{
+			TemplateContext: rules.TemplateContext{
+				GitURL:            "https://github.com/myorg/myapp.git",
+				Version:           "1.2.3",
+				AppName:           "myapp",
+				Namespace:         ns,
+				HelmRepositoryURL: "oci://chartmuseum-jx.34.78.195.22.nip.io",
+			},
+			Dir:           dir,
+			Config:        *cfg,
+			DevEnvContext: envctx,
+		}
+
+		e := helmfile.Rule(r)
+		require.Nil(t, e)
+		testhelpers.AssertTextFilesEqual(t, filepath.Join(src, "helmfile.yaml.expected"), filepath.Join(dir, "helmfile.yaml"), "The OCI prefix has not been removed before adding it to the helmfile")
+
+	}
+}

--- a/pkg/rules/helmfile/test_data/helmfile/helmfile.yaml
+++ b/pkg/rules/helmfile/test_data/helmfile/helmfile.yaml
@@ -1,0 +1,8 @@
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+releases:
+- name: dbmigrator
+  labels:
+    job: dbmigrator
+  chart: ./dbmigrator

--- a/pkg/rules/helmfile/test_data/helmfile/helmfile.yaml.expected
+++ b/pkg/rules/helmfile/test_data/helmfile/helmfile.yaml.expected
@@ -1,0 +1,18 @@
+filepath: ""
+repositories:
+- name: yourorg
+  url: https://yourorg.example.com/charts
+- name: dev
+  url: chartmuseum-jx.34.78.195.22.nip.io
+  oci: true
+releases:
+- chart: ./dbmigrator
+  name: dbmigrator
+  labels:
+    job: dbmigrator
+- chart: dev/myapp
+  version: 1.2.3
+  name: myapp
+  namespace: jx
+templates: {}
+renderedvalues: {}

--- a/pkg/rules/helmfile/test_data/jenkins-x-versions/packages/git.yml
+++ b/pkg/rules/helmfile/test_data/jenkins-x-versions/packages/git.yml
@@ -1,0 +1,4 @@
+version: 2.15.0
+upperLimit: 3.0.0
+gitUrl: https://github.com/git/git.git
+url: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git


### PR DESCRIPTION
The main issue is like this:

When having an oct-based helm registry (e.g. Harbor). Everything works fine if you set chartKind: oci and the fully prefixed URL in jx-requirements.yaml, except helmfile expects the url without prefix, and when the PR is created, then jx-verify fails, not being able to template the given repository.

As a solution I propose to remove the oci:// prefix right before appending it to the helmfile in the new PR.